### PR TITLE
[Bug#92201] Sửa tính năng chuyển đổi trạng thái đơn hàng của admin

### DIFF
--- a/lang/ja.json
+++ b/lang/ja.json
@@ -578,5 +578,9 @@
     "Password must be at least 8 characters long.": "パスワードは8文字以上である必要があります。",
     "Please select a role for the user.": "ユーザーの役割を選択してください。",
     "Error!": "エラー!",
-    "No new notifications": "新しい通知はありません"
+    "No new notifications": "新しい通知はありません。",
+    "From Pending status, you can only approve or reject the order.": "保留中のステータスから、注文を承認または拒否することができます。",
+    "From Approved status, you can only change to Delivering.": "承認済みのステータスから、配送中に変更することができます。",
+    "Rejected orders cannot be changed.": "拒否された注文は変更できません。",
+    "From Delivering status, you can only mark as Delivered.": "配送中のステータスから、配達済みにマークすることができます。"
 }

--- a/lang/vi.json
+++ b/lang/vi.json
@@ -579,5 +579,9 @@
     "Password must be at least 8 characters long.": "Mật khẩu phải có ít nhất 8 ký tự.",
     "Please select a role for the user.": "Vui lòng chọn vai trò cho người dùng.",
     "Error!": "Lỗi!",
-    "No new notifications": "Không có thông báo mới"
+    "No new notifications": "Không có thông báo mới",
+    "From Pending status, you can only approve or reject the order.": "Từ trạng thái Chờ Xử Lý, bạn chỉ có thể phê duyệt hoặc từ chối đơn hàng.",
+    "From Approved status, you can only change to Delivering.": "Từ trạng thái Đã Phê Duyệt, bạn chỉ có thể chuyển sang Đang Giao.",
+    "Rejected orders cannot be changed.": "Đơn hàng bị từ chối không thể thay đổi.",
+    "From Delivering status, you can only mark as Delivered.": "Từ trạng thái Đang Giao, bạn chỉ có thể đánh dấu là Đã Giao."
 }

--- a/resources/views/admin/components/modals.blade.php
+++ b/resources/views/admin/components/modals.blade.php
@@ -484,7 +484,7 @@
                 <div style="background: #fff3cd; border: 1px solid #ffeaa7; border-radius: 8px; padding: 15px; margin-bottom: 20px;">
                     <p style="margin: 0; color: #856404; font-weight: 500;">
                         <i class="fas fa-info-circle" style="margin-right: 8px;"></i>
-                        {{ __('Once you change the status to "Delivered" or "Cancelled", you will not be able to change it again.') }}
+                        {{ __('Once you change the status to "Delivered", you will not be able to change it again.') }}
                     </p>
                 </div>
                 <p style="margin: 10px 0; color: #333;">

--- a/resources/views/admin/pages/orders.blade.php
+++ b/resources/views/admin/pages/orders.blade.php
@@ -136,15 +136,24 @@
                                 @csrf
                                 @method('PATCH')
                                 <select name="status" class="form-control order-status-select" style="width:auto;" 
-                                        {{ in_array($status, ['delivered', 'cancelled']) ? 'disabled' : '' }}>
-                                    <option value="pending" {{ $status==='pending' ? 'selected' : '' }}>{{ __('Pending') }}</option>
-                                    <option value="approved" {{ $status==='approved' ? 'selected' : '' }}>{{ __('Approve') }}</option>
-                                    <option value="rejected" {{ $status==='rejected' ? 'selected' : '' }}>{{ __('Reject') }}</option>
-                                    <option value="delivering" {{ $status==='delivering' ? 'selected' : '' }}>{{ __('Delivering') }}</option>
-                                    <option value="delivered" {{ $status==='delivered' ? 'selected' : '' }}>{{ __('Delivered') }}</option>
+                                        {{ in_array($status, ['delivered', 'cancelled', 'rejected']) ? 'disabled' : '' }}>
+                                    @if($status === 'pending')
+                                        <option value="pending" selected>{{ __('Pending') }}</option>
+                                        <option value="approved">{{ __('Approve') }}</option>
+                                        <option value="rejected">{{ __('Reject') }}</option>
+                                    @elseif($status === 'approved')
+                                        <option value="approved" selected>{{ __('Approved') }}</option>
+                                        <option value="delivering">{{ __('Delivering') }}</option>
+                                    @elseif($status === 'delivering')
+                                        <option value="delivering" selected>{{ __('Delivering') }}</option>
+                                        <option value="delivered">{{ __('Delivered') }}</option>
+                                    @else
+                                        {{-- rejected, delivered, cancelled -> show current status only --}}
+                                        <option value="{{ $status }}" selected>{{ $statusText }}</option>
+                                    @endif
                                 </select>
                                 <button type="submit" class="btn btn-success btn-sm order-status-submit" 
-                                        {{ in_array($status, ['delivered', 'cancelled']) ? 'disabled' : '' }}>
+                                        {{ in_array($status, ['delivered', 'cancelled', 'rejected']) ? 'disabled' : '' }}>
                                     <i class="fas fa-save"></i> {{ __('Update') }}
                                 </button>
                             </form>
@@ -371,13 +380,13 @@
                     
                     const newStatus = statusSelect.value;
                     
-                    if (['delivered', 'cancelled'].includes(currentStatus)) {
-                        adminPanel.openModal('orderStatusErrorModal');
+                    // if status is not changing -> do nothing
+                    if (currentStatus === newStatus) {
                         return;
                     }
                     
-                    // check if new status is final and show warning
-                    if (['delivered', 'cancelled'].includes(newStatus) && newStatus !== currentStatus) {
+                    // Show warning for final status transitions
+                    if (['delivered'].includes(newStatus)) {
                         adminPanel.openModal('orderStatusWarningModal');
                         
                         const confirmBtn = document.getElementById('confirmStatusChangeBtn');

--- a/resources/views/customer/pages/order-details.blade.php
+++ b/resources/views/customer/pages/order-details.blade.php
@@ -269,11 +269,6 @@
     color: #721c24;
 }
 
-.status-delivering {
-    background: #fff3cd;
-    color: #856404;
-}
-
 .status-delivered {
     background: #d4edda;
     color: #155724;

--- a/resources/views/customer/pages/orders.blade.php
+++ b/resources/views/customer/pages/orders.blade.php
@@ -395,13 +395,13 @@
 }
 
 .status-delivering {
-    background: #d4edda;
-    color: #155724;
+    background: #d1ecf1;
+    color: #0c5460;
 }
 
 .status-delivered {
-    background: #d1ecf1;
-    color: #0c5460;
+    background: #d4edda;
+    color: #155724;
 }
 
 .status-cancelled {


### PR DESCRIPTION
- [ticket](https://edu-redmine.sun-asterisk.vn/issues/92201)
- Trước đây admin có thể tùy ý đổi trạng thái bất kỳ, nhưng nếu đã chuyển sang cancelled hoặc delivered thì sẽ không thể chuyển đổi sang trạng thái khác nữa.
- Giờ đây, admin phải chuyển đổi tuần tự: từ pending sang approve (hoặc reject), từ approve sang delivering, rồi từ delivering mới sang được delivered.